### PR TITLE
Updates to the icon-no-coll file plus compile bug fix

### DIFF
--- a/.tdnbuild
+++ b/.tdnbuild
@@ -4,7 +4,7 @@
 		
 		"default-definition-packs": [
 			
-			"../../Minecraft-Definitions/featuremaps/defpacks/zipped/minecraft_j_1_18.zip"
+			"../../Minecraft-Definitions/defpacks/zipped/minecraft_j_1_18.zip"
 			
 		],
 		"feature-map": "../../Minecraft-Definitions/featuremaps/j_1_18.json",

--- a/datapack/data/warppad/tags/blocks/icon_no_coll.json
+++ b/datapack/data/warppad/tags/blocks/icon_no_coll.json
@@ -1,12 +1,18 @@
 {
     "values": [
         "#warppad:air",
+        "#warppad:panes",
         "minecraft:water",
         "minecraft:tall_grass",
         "minecraft:torch",
         "minecraft:soul_torch",
         "minecraft:lantern",
         "minecraft:soul_lantern",
+        "minecraft:mangrove_propagule",
+        "minecraft:sculk_vein",
+        "minecraft:glow_lichen",
+        "minecraft:redstone_torch",
+        "minecraft:scaffolding",
         "#minecraft:buttons",
         "#minecraft:candles",
         "#minecraft:carpets",
@@ -21,6 +27,7 @@
         "#minecraft:saplings",
         "#minecraft:signs",
         "#minecraft:trapdoors",
-        "#minecraft:wall_corals"
+        "#minecraft:wall_corals",
+        "#minecraft:impermeable"
     ]
 }

--- a/datapack/data/warppad/tags/blocks/icon_no_coll.json
+++ b/datapack/data/warppad/tags/blocks/icon_no_coll.json
@@ -12,7 +12,6 @@
         "minecraft:sculk_vein",
         "minecraft:glow_lichen",
         "minecraft:redstone_torch",
-        "minecraft:scaffolding",
         "#minecraft:buttons",
         "#minecraft:candles",
         "#minecraft:carpets",

--- a/datapack/data/warppad/tags/blocks/panes.json
+++ b/datapack/data/warppad/tags/blocks/panes.json
@@ -1,0 +1,21 @@
+{
+    "values":[
+        "minecraft.glass_pane",
+        "minecraft.white_stained_glass_pane",
+        "minecraft.orange_stained_glass_pane",
+        "minecraft.magenta_stained_glass_pane",
+        "minecraft.light_blue_stained_glass_pane",
+        "minecraft.yellow_stained_glass_pane",
+        "minecraft.lime_stained_glass_pane",
+        "minecraft.pink_stained_glass_pane",
+        "minecraft.gray_stained_glass_pane",
+        "minecraft.light_gray_stained_glass_pane",
+        "minecraft.cyan_stained_glass_pane",
+        "minecraft.purple_stained_glass_pane",
+        "minecraft.blue_stained_glass_pane",
+        "minecraft.brown_stained_glass_pane",
+        "minecraft.green_stained_glass_pane",
+        "minecraft.red_stained_glass_pane",
+        "minecraft.black_stained_glass_pane"
+    ]
+}

--- a/datapack/data/warppad/tags/blocks/panes.json
+++ b/datapack/data/warppad/tags/blocks/panes.json
@@ -1,21 +1,21 @@
 {
     "values":[
-        "minecraft.glass_pane",
-        "minecraft.white_stained_glass_pane",
-        "minecraft.orange_stained_glass_pane",
-        "minecraft.magenta_stained_glass_pane",
-        "minecraft.light_blue_stained_glass_pane",
-        "minecraft.yellow_stained_glass_pane",
-        "minecraft.lime_stained_glass_pane",
-        "minecraft.pink_stained_glass_pane",
-        "minecraft.gray_stained_glass_pane",
-        "minecraft.light_gray_stained_glass_pane",
-        "minecraft.cyan_stained_glass_pane",
-        "minecraft.purple_stained_glass_pane",
-        "minecraft.blue_stained_glass_pane",
-        "minecraft.brown_stained_glass_pane",
-        "minecraft.green_stained_glass_pane",
-        "minecraft.red_stained_glass_pane",
-        "minecraft.black_stained_glass_pane"
+        "minecraft:glass_pane",
+        "minecraft:white_stained_glass_pane",
+        "minecraft:orange_stained_glass_pane",
+        "minecraft:magenta_stained_glass_pane",
+        "minecraft:light_blue_stained_glass_pane",
+        "minecraft:yellow_stained_glass_pane",
+        "minecraft:lime_stained_glass_pane",
+        "minecraft:pink_stained_glass_pane",
+        "minecraft:gray_stained_glass_pane",
+        "minecraft:light_gray_stained_glass_pane",
+        "minecraft:cyan_stained_glass_pane",
+        "minecraft:purple_stained_glass_pane",
+        "minecraft:blue_stained_glass_pane",
+        "minecraft:brown_stained_glass_pane",
+        "minecraft:green_stained_glass_pane",
+        "minecraft:red_stained_glass_pane",
+        "minecraft:black_stained_glass_pane"
     ]
 }


### PR DESCRIPTION
Closes #6 temporarily until MCDefs gives us 1.19 mappings.
-Added all glass and all glass panes (glass using the #impermeable tag)
-Mangrove Propagules (Future proofing, does in fact seem to work)
-Skulk Veins (Future proofing, does not seem to work atm)
-Redstone torch
-Glow lichen

Fixes path error in .tdnbuild to reflect changes in MCDefs so the pack compiles again.